### PR TITLE
Reimplement `computeTorque()` for Accurate B1 Motor Simulation

### DIFF
--- a/unitree_legged_control/src/joint_controller.cpp
+++ b/unitree_legged_control/src/joint_controller.cpp
@@ -177,7 +177,8 @@ namespace unitree_legged_control
 
         currentPos = joint.getPosition();
         currentVel = computeVel(currentPos, (double)lastState.q, (double)lastState.dq, period.toSec());
-        calcTorque = computeTorque(currentPos, currentVel, servoCmd);      
+        calcTorque = servoCmd.torque + servoCmd.posStiffness*(servoCmd.pos - currentPos)
+            + servoCmd.velStiffness*(servoCmd.vel - currentVel);
         effortLimits(calcTorque);
 
         joint.setCommand(calcTorque);


### PR DESCRIPTION
### Description:
This pull request addresses issue [#66](https://github.com/unitreerobotics/unitree_ros/issues/66), which identifies the clamping of joint torque commands to ±55 Nm by `UnitreeJointController`. This limitation hinders the accurate simulation of B1 motors, which have ±140 Nm capability.

The impact is evident in the following visualizations, where B1 is commanded to trot in place:

| ![b1_default](https://github.com/unitreerobotics/unitree_ros/assets/8316042/a1bb76d2-3662-4e80-a930-4768c4a8dd10) | ![b1_default](https://github.com/unitreerobotics/unitree_ros/assets/8316042/5975fb4a-826c-40dd-a56b-90341147a449) |
| :---: | :---: |
| *B1 attempting to trot in Gazebo* | *Torque clamping to 55 Nm* |

### Problem:
The issue lies in `UnitreeJointController`'s usage *([line 180](https://github.com/unitreerobotics/unitree_ros/blob/67ac2124494e93af87d34d6e53ef9060dbf9c923/unitree_legged_control/src/joint_controller.cpp#L180), below)* of the [`computeTorque()`](https://github.com/unitreerobotics/unitree_ros/blob/67ac2124494e93af87d34d6e53ef9060dbf9c923/unitree_legged_control/include/unitree_joint_control_tool.h#L31) function from [unitree_ros/unitree_legged_control/lib](https://github.com/unitreerobotics/unitree_ros/tree/67ac2124494e93af87d34d6e53ef9060dbf9c923/unitree_legged_control/lib), which inadvertently clamps its output to ±55 Nm.

https://github.com/paulblum/unitree_ros/blob/cea22a6f433c596b5fcb3497bd61b28ddba2d56f/unitree_legged_control/src/joint_controller.cpp#L178-L181

Notably, this clamping is redundant, as the joint torque computation is already clamped to URDF specifications *([line 181](https://github.com/unitreerobotics/unitree_ros/blob/67ac2124494e93af87d34d6e53ef9060dbf9c923/unitree_legged_control/src/joint_controller.cpp#L181), above)* by the [`effortLimits()`](https://github.com/unitreerobotics/unitree_ros/blob/67ac2124494e93af87d34d6e53ef9060dbf9c923/unitree_legged_control/src/joint_controller.cpp#L220-L224) function.

### Solution:
This pull request proposes the removal of the ±55 Nm clamp from `computeTorque()`, introducing the following implementation:

```cpp
calcTorque = servoCmd.torque + servoCmd.posStiffness*(servoCmd.pos - currentPos)
    + servoCmd.velStiffness*(servoCmd.vel - currentVel);
```

### Rationale:
This modification allows for the utilization of `UnitreeJointController` to accurately simulate B1 control, while preserving its original functionality for smaller quadrupeds.

| ![b1_updated](https://github.com/unitreerobotics/unitree_ros/assets/8316042/37bdb751-9259-415d-aef2-31af26d1df70) | ![b1_updated](https://github.com/unitreerobotics/unitree_ros/assets/8316042/cbd8edff-e422-447f-bf2c-6c1ad98a3c24) |
| :---: | :---: |
| *B1 trotting in Gazebo via updated code* | *Update enables accurate B1 torque computation* |

| ![a1_updated](https://github.com/unitreerobotics/unitree_ros/assets/8316042/2725ff5a-5a26-4ccd-ae40-2cbdb7bf1420) | ![a1_updated](https://github.com/unitreerobotics/unitree_ros/assets/8316042/a2ba8579-1fee-450a-a729-dbb712f84492) |
| :---: | :---: |
| *A1 trotting in Gazebo via updated code* | *Update maintains identical torque computation in the [-55,55] Nm range* |